### PR TITLE
Add sample LLM web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # Abn
+
+This project is a minimal example of a web app that can query different large language model providers such as Google's Gemini or Anthropic Claude. The app uses Flask for a simple backend and renders a basic HTML form.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Set the provider you want to use with environment variables. Example:
+   ```bash
+   export LLM_PROVIDER=gemini
+   export GEMINI_API_KEY=your_key_here
+   ```
+   or for Anthropic:
+   ```bash
+   export LLM_PROVIDER=anthropic
+   export ANTHROPIC_API_KEY=your_key_here
+   ```
+
+3. Run the server:
+   ```bash
+   python app.py
+   ```
+
+Open your browser at `http://localhost:5000` and try a prompt.
+
+## Running Tests
+
+```
+pytest
+```
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,18 @@
+from flask import Flask, request, render_template, jsonify
+import os
+import requests
+from llm_providers import send_prompt
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    response_text = None
+    if request.method == 'POST':
+        prompt = request.form.get('prompt', '')
+        if prompt:
+            response_text = send_prompt(prompt)
+    return render_template('index.html', response_text=response_text)
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0')

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -1,0 +1,68 @@
+import os
+import requests
+
+class LLMProvider:
+    def send(self, prompt: str) -> str:
+        raise NotImplementedError
+
+class GeminiProvider(LLMProvider):
+    def __init__(self):
+        self.api_key = os.getenv('GEMINI_API_KEY')
+        self.endpoint = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateText'
+
+    def send(self, prompt: str) -> str:
+        if not self.api_key:
+            return 'GEMINI_API_KEY not configured.'
+        data = {
+            'prompt': {
+                'text': prompt
+            }
+        }
+        params = {'key': self.api_key}
+        resp = requests.post(self.endpoint, json=data, params=params, timeout=30)
+        try:
+            resp.raise_for_status()
+            content = resp.json().get('candidates', [{}])[0].get('output', '')
+        except Exception:
+            content = f'Error: {resp.text}'
+        return content
+
+class AnthropicProvider(LLMProvider):
+    def __init__(self):
+        self.api_key = os.getenv('ANTHROPIC_API_KEY')
+        self.endpoint = 'https://api.anthropic.com/v1/complete'
+
+    def send(self, prompt: str) -> str:
+        if not self.api_key:
+            return 'ANTHROPIC_API_KEY not configured.'
+        headers = {
+            'x-api-key': self.api_key,
+            'content-type': 'application/json'
+        }
+        data = {
+            'prompt': prompt,
+            'model': 'claude-2',
+            'max_tokens': 256
+        }
+        resp = requests.post(self.endpoint, headers=headers, json=data, timeout=30)
+        try:
+            resp.raise_for_status()
+            content = resp.json().get('completion', '')
+        except Exception:
+            content = f'Error: {resp.text}'
+        return content
+
+PROVIDERS = {
+    'gemini': GeminiProvider,
+    'anthropic': AnthropicProvider,
+}
+
+
+def send_prompt(prompt: str) -> str:
+    provider_name = os.getenv('LLM_PROVIDER', 'gemini')
+    ProviderClass = PROVIDERS.get(provider_name)
+    if not ProviderClass:
+        return f'Unknown provider {provider_name}'
+    provider = ProviderClass()
+    return provider.send(prompt)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,8 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 2em;
+}
+
+textarea {
+    width: 100%;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>LLM Playground</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>LLM Playground</h1>
+    <form method="post">
+        <label for="prompt">Enter your prompt:</label><br>
+        <textarea id="prompt" name="prompt" rows="4" cols="50"></textarea><br>
+        <button type="submit">Send</button>
+    </form>
+    {% if response_text %}
+    <h2>Response</h2>
+    <pre>{{ response_text }}</pre>
+    {% endif %}
+</body>
+</html>

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,14 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import os
+import llm_providers
+
+class DummyProvider(llm_providers.LLMProvider):
+    def send(self, prompt: str) -> str:
+        return f"dummy:{prompt}"
+
+llm_providers.PROVIDERS['dummy'] = DummyProvider
+
+def test_send_prompt_env(monkeypatch):
+    monkeypatch.setenv('LLM_PROVIDER', 'dummy')
+    assert llm_providers.send_prompt('hi') == 'dummy:hi'
+


### PR DESCRIPTION
## Summary
- build a tiny Flask website that can talk to multiple LLM providers
- add Gemini and Anthropic provider wrappers
- create simple HTML form and stylesheet
- include tests for provider selection
- document setup and usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688599bf57bc832fafe1f196108e3cbc